### PR TITLE
Add some variables for volume bar color.

### DIFF
--- a/src/gnome-shell/gnome-shell-aliz.css
+++ b/src/gnome-shell/gnome-shell-aliz.css
@@ -1100,7 +1100,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: rgba(0, 0, 0, 0.8);
   -barlevel-height: 3px;
   -barlevel-background-color: transparent;
-  -barlevel-active-background-color: #00C853;
+  -barlevel-active-background-color: #f4817b;
   -barlevel-overdrive-color: #FF5252;
   -barlevel-overdrive-separator-width: 3px;
   -barlevel-border-width: 0;

--- a/src/gnome-shell/gnome-shell-azul.css
+++ b/src/gnome-shell/gnome-shell-azul.css
@@ -1100,7 +1100,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: rgba(0, 0, 0, 0.8);
   -barlevel-height: 3px;
   -barlevel-background-color: transparent;
-  -barlevel-active-background-color: #42A5F5;
+  -barlevel-active-background-color: #3498db;
   -barlevel-overdrive-color: #FF5252;
   -barlevel-overdrive-separator-width: 3px;
   -barlevel-border-width: 0;

--- a/src/gnome-shell/gnome-shell-azul.css
+++ b/src/gnome-shell/gnome-shell-azul.css
@@ -1100,7 +1100,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: rgba(0, 0, 0, 0.8);
   -barlevel-height: 3px;
   -barlevel-background-color: transparent;
-  -barlevel-active-background-color: #00C853;
+  -barlevel-active-background-color: #42A5F5;
   -barlevel-overdrive-color: #FF5252;
   -barlevel-overdrive-separator-width: 3px;
   -barlevel-border-width: 0;

--- a/src/gnome-shell/gnome-shell-dark-aliz.css
+++ b/src/gnome-shell/gnome-shell-dark-aliz.css
@@ -1096,7 +1096,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: rgba(255, 255, 255, 0.85);
   -barlevel-height: 3px;
   -barlevel-background-color: transparent;
-  -barlevel-active-background-color: #00C853;
+  -barlevel-active-background-color: #f4817b;
   -barlevel-overdrive-color: #FF5252;
   -barlevel-overdrive-separator-width: 3px;
   -barlevel-border-width: 0;

--- a/src/gnome-shell/gnome-shell-dark-azul.css
+++ b/src/gnome-shell/gnome-shell-dark-azul.css
@@ -1096,7 +1096,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: rgba(255, 255, 255, 0.85);
   -barlevel-height: 3px;
   -barlevel-background-color: transparent;
-  -barlevel-active-background-color: #42A5F5;
+  -barlevel-active-background-color: #3498db;
   -barlevel-overdrive-color: #FF5252;
   -barlevel-overdrive-separator-width: 3px;
   -barlevel-border-width: 0;

--- a/src/gnome-shell/gnome-shell-dark-azul.css
+++ b/src/gnome-shell/gnome-shell-dark-azul.css
@@ -1096,7 +1096,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: rgba(255, 255, 255, 0.85);
   -barlevel-height: 3px;
   -barlevel-background-color: transparent;
-  -barlevel-active-background-color: #00C853;
+  -barlevel-active-background-color: #42A5F5;
   -barlevel-overdrive-color: #FF5252;
   -barlevel-overdrive-separator-width: 3px;
   -barlevel-border-width: 0;

--- a/src/gnome-shell/sass/_colors.scss
+++ b/src/gnome-shell/sass/_colors.scss
@@ -87,3 +87,7 @@ $info_bg_color: #66BB6A;
 $question_bg_color: #42A5F5;
 $warning_bg_color: #FFA726;
 $error_bg_color: #EF5350;
+
+$volume_bar_bg_color: #00C853;
+@if $color=='aliz' { $volume_bar_bg_color: #f4817b; }
+@if $color=='azul' { $volume_bar_bg_color: #3498db; }

--- a/src/gnome-shell/sass/_common.scss
+++ b/src/gnome-shell/sass/_common.scss
@@ -933,7 +933,7 @@ StScrollBar {
     // FIXME: above 'background-color' property rendered correct trough
     // colour already, so keep -background-color style-property transparent
     -barlevel-background-color: transparent;
-    -barlevel-active-background-color: $question_bg_color;
+    -barlevel-active-background-color: $volume_bar_bg_color;
     -barlevel-overdrive-color: $destructive_color;
     -barlevel-overdrive-separator-width: 3px;
     -barlevel-border-width: 0;

--- a/src/gnome-shell/sass/_common.scss
+++ b/src/gnome-shell/sass/_common.scss
@@ -933,7 +933,7 @@ StScrollBar {
     // FIXME: above 'background-color' property rendered correct trough
     // colour already, so keep -background-color style-property transparent
     -barlevel-background-color: transparent;
-    -barlevel-active-background-color: $success_color;
+    -barlevel-active-background-color: $question_bg_color;
     -barlevel-overdrive-color: $destructive_color;
     -barlevel-overdrive-separator-width: 3px;
     -barlevel-border-width: 0;


### PR DESCRIPTION
As mentioned on issue https://github.com/vinceliuice/Matcha-gtk-theme/issues/120, fixes for volume bar color were not included. So, i created some variables.

This pull request include some variables for volume-bar-background and color corrections. In addition to Azul theme, Aliz theme has been fixed too, cause the volume-bar-background was green.