### PR TITLE
New gedit theme

### DIFF
--- a/src/extra/gedit/README.md
+++ b/src/extra/gedit/README.md
@@ -2,11 +2,11 @@
 This theme provides styles for HTML, CSS, DIFF, INI, JAVA, JS, JSON, MD, PERL, PHP, PYTHON, RUBY, SH, XML, C.  
 
 ### Installation  
-Copy the [`Matcha.xml`](/extra/gedit/Matcha.xml) file to the color schemes directory:  
+Copy the [`Matcha.xml`](matcha.xml) or [`Matchav2.xml`](matchav2.xml) file to the color schemes directory:  
 `~/.local/share/gedit/styles` or `~/.local/share/gtksourceview-3.0/styles`
 
 ### Activation
   1. Open the Preferences in Gedit
   2. Switch to the "Font & Colors" tab
-  3. Select `Matcha Gedit` from the "Color Scheme" list
+  3. Select `Matcha Gedit or Matcha Gedit v2` from the "Color Scheme" list
   4. Enjoy

--- a/src/extra/gedit/matchav2.xml
+++ b/src/extra/gedit/matchav2.xml
@@ -1,0 +1,352 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<style-scheme id="matchav2" name="Matcha Gedit v2" filename="Matchav2.xml" version="1.0">
+  <author>DionWeb</author>
+  <description>Gedit theme for matcha GTK theme.</description>
+
+  <!-- Color Palette -->
+  <color name="matcha1"                     value="#7e8e8c" />
+  <color name="matcha2"                     value="#cfdcd8" />
+  <color name="matcha3"                     value="#1ecca9" />
+  <color name="matcha4"                     value="#F0544C" />
+  <color name="matcha5"                     value="#3498db" />
+  <color name="matcha6"                     value="#42A5F5" />
+  <color name="matcha7"                     value="#F0544C" />
+  <color name="matcha8"                     value="#F0544C" />
+  <color name="matcha9"                     value="#2eb398" />
+  <color name="matcha10"                    value="#ad7fa8" />
+  <color name="matcha11"                    value="#283334" />
+
+  <!-- GUI Styling -->
+  <style name="bookmark"                    background="matcha2" />
+  <style name="bracket-match"               foreground="matcha2" />
+  <style name="bracket-mismatch"            foreground="matcha4" underline="true" />
+  <style name="current-line"                background="#eaeaea"/>
+  <style name="cursor"                      foreground="matcha2" />
+
+  <style name="search-match"                foreground="matcha2" background="matcha6" />
+  <style name="secondary-cursor"            use-style="cursor" />
+  <style name="right-margin"                foreground="matcha2" />
+  <style name="text"                        foreground="" />
+
+  <!-- Custom definitions -->
+  <style name="def:annotation"              foreground="matcha7" />
+  <style name="def:escape"                  foreground="matcha7" />
+  <style name="def:regexp"                  foreground="matcha8" />
+  <style name="def:symbol"                  foreground="matcha2" />
+  <style name="def:other"                   foreground="matcha2" />
+  <style name="def:verbatim"                foreground="matcha8" />
+
+  <!-- Variables -->
+  <style name="def:number"                  foreground="matcha10" />
+  <style name="def:string"                  foreground="matcha9" />
+  <style name="def:base-n-integer"          use-style="def:number" />
+  <style name="def:character"               use-style="def:string" />
+  <style name="def:complex"                 use-style="def:number" />
+  <style name="def:decimal"                 use-style="def:number" />
+  <style name="def:floating-point"          use-style="def:number" />
+  <style name="def:special-char"            foreground="matcha7" />
+  <style name="def:variable"                foreground="matcha2" />
+  <style name="def:global-variable"         foreground="matcha2" />
+  <style name="def:class-variable"          foreground="matcha2" />
+  <style name="def:instance-variable"       foreground="matcha2" />
+
+  <!-- Constants -->
+  <style name="def:boolean"                 foreground="matcha5" />
+  <style name="def:constant"                foreground="matcha2" />
+  <style name="def:namespace"               foreground="matcha3" />
+  <style name="def:special-constant"        foreground="matcha5" />
+
+  <!-- Comments -->
+  <style name="def:comment"                 foreground="matcha1" italic="true" />
+  <style name="def:doc-comment"             use-style="def:comment" />
+  <style name="def:doc-comment-element"     foreground="matcha5" />
+  <style name="def:net-address-in-comment"  foreground="matcha1" underline="true" />
+  <style name="def:note"                    use-style="def:comment" />
+
+  <!-- Keywords -->
+  <style name="def:class"                   foreground="matcha3" />
+  <style name="def:keyword"                 foreground="matcha5" />
+  <style name="def:attribute"               use-style="def:class" />
+  <style name="def:builtin"                 use-style="def:keyword" />
+  <style name="def:identifier"              use-style="def:keyword" />
+  <style name="def:preprocessor"            foreground="matcha6" />
+  <style name="def:reserved"                use-style="def:keyword" />
+  <style name="def:shebang"                 foreground="matcha6" />
+  <style name="def:statement"               use-style="def:keyword" />
+  <style name="def:tag"                     use-style="def:keyword" />
+  <style name="def:type"                    use-style="def:class" />
+
+  <!-- Logicals -->
+  <style name="def:error"                   foreground="matcha4" />
+  <style name="def:function"                foreground="matcha4" />
+  <style name="def:operator"                foreground="matcha5" />
+
+  <!-- Headings -->
+  <style name="def:heading0"                foreground="matcha4" />
+  <style name="def:heading1"                use-style="def:heading0" />
+  <style name="def:heading2"                use-style="def:heading0" />
+  <style name="def:heading3"                use-style="def:heading0" />
+  <style name="def:heading4"                use-style="def:heading0" />
+  <style name="def:heading5"                use-style="def:heading0" />
+  <style name="def:heading6"                use-style="def:heading0" />
+
+  <!-- Formats -->
+  <style name="def:underlined"              underline="true" />
+  <style name="def:warning"                 foreground="matcha8" />
+
+  <!-- CSS Styling -->
+  <style name="css:at-rules"                use-style="def:annotation" />
+  <style name="css:block"                   use-style="def:symbol" />
+  <style name="css:color"                   use-style="def:number" />
+  <style name="css:comment"                 use-style="def:comment" />
+  <style name="css:decimal"                 use-style="def:decimal" />
+  <style name="css:dimension"               use-style="def:number" />
+  <style name="css:error"                   use-style="def:error" />
+  <style name="css:function"                use-style="def:function" />
+  <style name="css:keyword"                 use-style="def:attribute" />
+  <style name="css:others-2"                use-style="def:symbol" />
+  <style name="css:others-3"                use-style="def:symbol" />
+  <style name="css:property-values"         use-style="def:keyword" />
+  <style name="css:selector-class"          use-style="def:class" />
+  <style name="css:selector-id"             foreground="matcha3" underline="true" />
+  <style name="css:selector-tagname"        use-style="def:tag" />
+  <style name="css:string"                  use-style="def:string" />
+
+  <!-- Desktop Styling -->
+  <style name="desktop:boolean"             use-style="def:boolean" />
+  <style name="desktop:category-additional" use-style="def:string" />
+  <style name="desktop:category-main"       foreground="matcha9" bold="true" />
+  <style name="desktop:category-reserved"   foreground="matcha5" underline="true" />
+  <style name="desktop:encoding"            use-style="def:keyword" />
+  <style name="desktop:exec-parameter"      use-style="def:escape" />
+  <style name="desktop:group"               use-style="def:keyword" />
+  <style name="desktop:key"                 use-style="def:attribute" />
+  <style name="desktop:language"            use-style="def:string" />
+  <style name="desktop:number"              use-style="def:number" />
+
+  <!-- DIFF Styling -->
+  <style name="diff:added-line"             foreground="matcha9" />
+  <style name="diff:changed-line"           foreground="matcha8" />
+  <style name="diff:diff-file"              foreground="matcha4" />
+  <style name="diff:location"               foreground="matcha5" />
+  <style name="diff:removed-line"           foreground="matcha4" />
+  <style name="diff:special-case"           use-style="def:string" />
+
+  <!-- HTML Styling -->
+  <style name="html:attrib-name"            use-style="def:class" />
+  <style name="html:attrib-value"           use-style="def:string" />
+  <style name="html:comment"                use-style="def:comment" />
+  <style name="html:dtd"                    use-style="def:shebang" />
+  <style name="html:error"                  foreground="def:error" />
+  <style name="html:h1"                     use-style="text" />
+  <style name="html:h2"                     use-style="text" />
+  <style name="html:h3"                     use-style="text" />
+  <style name="html:h4"                     use-style="text" />
+  <style name="html:h5"                     use-style="text" />
+  <style name="html:tag"                    use-style="def:keyword" />
+  <style name="html:title"                  use-style="text" />
+
+  <!-- INI Styling -->
+  <style name="ini:boolean-value"           use-style="def:boolean" />
+  <style name="ini:comment"                 use-style="def:comment" />
+  <style name="ini:decimal"                 use-style="def:number" />
+  <style name="ini:floating-point"          use-style="def:number" />
+  <style name="ini:keyword"                 use-style="def:keyword" />
+  <style name="ini:non-standard-key"        italic="true" />
+  <style name="ini:string"                  use-style="def:string" />
+  <style name="ini:variable"                use-style="def:variable" />
+
+  <!-- JAVA Styling -->
+  <style name="java:boolean"                use-style="def:boolean" />
+  <style name="java:char"                   use-style="def:character" />
+  <style name="java:comment"                use-style="def:comment" />
+  <style name="java:declaration"            use-style="def:variable" />
+  <style name="java:escaped-character"      use-style="def:escape" />
+  <style name="java:external"               use-style="def:preprocessor" />
+  <style name="java:keyword"                use-style="def:keyword" />
+  <style name="java:null-value"             use-style="def:keyword" />
+  <style name="java:number"                 use-style="def:number" />
+  <style name="java:reserved"               use-style="def:constant" />
+  <style name="java:scope-declaration"      use-style="def:keyword" />
+  <style name="java:storage-class"          use-style="def:keyword" />
+  <style name="java:string"                 use-style="def:string" />
+  <style name="java:type"                   use-style="def:keyword" />
+
+  <!-- JS Styling -->
+  <style name="js:boolean"                  use-style="def:boolean" />
+  <style name="js:constructors"             use-style="def:function" />
+  <style name="js:escape"                   use-style="def:escape" />
+  <style name="js:function"                 use-style="def:function" />
+  <style name="js:future-words"             use-style="def:keyword" />
+  <style name="js:keyword"                  use-style="def:keyword" />
+  <style name="js:null-value"               use-style="def:keyword" />
+  <style name="js:properties"               foreground="matcha4" italic="true" />
+  <style name="js:regex"                    use-style="def:regexp" />
+  <style name="js:string"                   use-style="def:string" />
+  <style name="js:type"                     use-style="def:keyword" />
+  <style name="js:undefined-value"          use-style="def:keyword" />
+
+  <!-- JSON Styling -->
+  <style name="json:boolean"                use-style="def:boolean" />
+  <style name="json:decimal"                use-style="def:decimal" />
+  <style name="json:error"                  use-style="def:error" />
+  <style name="json:float"                  use-style="def:floating-point" />
+  <style name="json:keyname"                use-style="def:keyword" />
+  <style name="json:null-value"             use-style="def:keyword" />
+  <style name="json:special-char"           use-style="def:special-char" />
+  <style name="json:string"                 use-style="def:string" />
+
+  <!-- MD Styling -->
+  <style name="markdown:abbreviation"       foreground="matcha7" />
+  <style name="markdown:attribute-value"    use-style="def:attribute" />
+  <style name="markdown:backslash-escape"   use-style="def:escape" />
+  <style name="markdown:blockquote-marker"  foreground="matcha4" />
+  <style name="markdown:code"               foreground="matcha3" />
+  <style name="markdown:emphasis"           foreground="matcha2" italic="true" />
+  <style name="markdown:header"             foreground="matcha4" />
+  <style name="markdown:horizontal-rule"    foreground="matcha5" />
+  <style name="markdown:image-marker"       use-style="def:keyword" />
+  <style name="markdown:label"              use-style="def:attribute" />
+  <style name="markdown:line-break"         use-style="def:comment" />
+  <style name="markdown:link-text"          use-style="def:attribute" />
+  <style name="markdown:list-marker"        foreground="matcha5" />
+  <style name="markdown:strong-emphasis"    foreground="matcha2" bold="true" />
+  <style name="markdown:table-separator"    bold="true" />
+  <style name="markdown:url"                foreground="matcha2" underline="true" />
+
+  <!-- PERL Styling -->
+  <style name="perl:builtin"                use-style="def:builtin" />
+  <style name="perl:comment"                use-style="def:comment" />
+  <style name="perl:control"                foreground="matcha5" underline="true" />
+  <style name="perl:error"                  use-style="def:error" />
+  <style name="perl:file-descriptor"        use-style="def:keyword" />
+  <style name="perl:here-doc-bound"         use-style="def:keyword" />
+  <style name="perl:include-statement"      use-style="def:annotation" />
+  <style name="perl:keyword"                use-style="def:keyword" />
+  <style name="perl:line-directive"         foreground="matcha1" italic="true" />
+  <style name="perl:operator"               use-style="def:operator" />
+  <style name="perl:pod"                    use-style="text" />
+  <style name="perl:pod-escape"             use-style="def:escape" />
+  <style name="perl:pod-heading"            foreground="matcha4" />
+  <style name="perl:pod-keyword"            use-style="def:keyword" />
+  <style name="perl:regex"                  use-style="def:regexp" />
+  <style name="perl:string"                 use-style="def:string" />
+  <style name="perl:system-command"         foreground="matcha4" />
+  <style name="perl:variable"               use-style="def:variable" />
+
+  <!-- PHP Styling -->
+  <style name="php:boolean"                 use-style="def:boolean" />
+  <style name="php:comment"                 use-style="def:comment" />
+  <style name="php:common-function"         use-style="def:function" />
+  <style name="php:decimal"                 use-style="def:number" />
+  <style name="php:error"                   use-style="def:error" />
+  <style name="php:escape"                  use-style="def:escape" />
+  <style name="php:floating-point"          use-style="def:number" />
+  <style name="php:here-doc"                use-style="def:string" />
+  <style name="php:here-doc-bound"          use-style="def:keyword" />
+  <style name="php:hexadecimal"             use-style="def:number" />
+  <style name="php:identifier"              use-style="def:function" />
+  <style name="php:keyword"                 use-style="def:keyword" />
+  <style name="php:null-value"              use-style="def:keyword" />
+  <style name="php:octal"                   foreground="matcha10" italic="true" />
+  <style name="php:operator"                use-style="def:operator" />
+  <style name="php:preprocessor"            use-style="def:preprocessor" />
+  <style name="php:string"                  use-style="def:string" />
+  <style name="php:type"                    use-style="def:class" />
+  <style name="php:variable"                use-style="def:variable" />
+
+  <!-- PYTHON Styling -->
+  <style name="python:base-n-integer"       foreground="matcha10" italic="true" />
+  <style name="python:boolean"              use-style="def:boolean" />
+  <style name="python:builtin-constant"     use-style="def:keyword" />
+  <style name="python:builtin-function"     use-style="def:function" />
+  <style name="python:builtin-object"       use-style="def:class" />
+  <style name="python:class-name"           use-style="def:class" />
+  <style name="python:complex"              foreground="matcha10" italic="true" />
+  <style name="python:decimal"              use-style="def:number" />
+  <style name="python:decorator"            use-style="def:annotation" />
+  <style name="python:escaped-char"         use-style="def:escape" />
+  <style name="python:floating-point"       use-style="def:number" />
+  <style name="python:format"               use-style="def:escape" />
+  <style name="python:function-name"        use-style="def:function" />
+  <style name="python:keyword"              use-style="def:keyword" />
+  <style name="python:module-handler"       use-style="def:keyword" />
+  <style name="python:multiline-string"     use-style="def:string" />
+  <style name="python:special-variable"     use-style="def:keyword" />
+  <style name="python:string"               use-style="def:string" />
+  <style name="python:string-conversion"    use-style="def:keyword" />
+  <style name="python3:base-n-integer"      foreground="matcha10" italic="true" />
+  <style name="python3:boolean"             use-style="def:boolean" />
+  <style name="python3:builtin-constant"    use-style="def:keyword" />
+  <style name="python3:builtin-function"    use-style="def:function" />
+  <style name="python3:builtin-object"      use-style="def:class" />
+  <style name="python3:complex"             foreground="matcha10" italic="true" />
+  <style name="python3:decimal"             use-style="def:number" />
+  <style name="python3:escaped-char"        use-style="def:escape" />
+  <style name="python3:floating-point"      use-style="def:number" />
+  <style name="python3:format"              use-style="def:escape" />
+  <style name="python3:keyword"             use-style="def:keyword" />
+  <style name="python3:module-handler"      use-style="def:keyword" />
+  <style name="python3:multiline-string"    use-style="def:string" />
+  <style name="python3:special-variable"    use-style="def:keyword" />
+  <style name="python3:string"              use-style="def:string" />
+
+  <!-- RUBY Styling -->
+  <style name="ruby:base-n-integer"         use-style="def:number" />
+  <style name="ruby:boolean"                use-style="def:boolean" />
+  <style name="ruby:builtin"                use-style="def:class" />
+  <style name="ruby:comment"                use-style="def:comment" />
+  <style name="ruby:constant"               use-style="def:class" />
+  <style name="ruby:decimal"                use-style="def:number" />
+  <style name="ruby:escape"                 use-style="def:escape" />
+  <style name="ruby:floating-point"         use-style="def:number" />
+  <style name="ruby:here-doc"               use-style="def:string" />
+  <style name="ruby:here-doc-bound"         use-style="def:keyword" />
+  <style name="ruby:keyword"                use-style="def:keyword" />
+  <style name="ruby:literal"                use-style="def:escape" />
+  <style name="ruby:module-handler"         use-style="def:keyword" />
+  <style name="ruby:nil-value"              use-style="def:keyword" />
+  <style name="ruby:numeric-literal"        use-style="def:number" />
+  <style name="ruby:predefined-variable"    use-style="def:keyword" />
+  <style name="ruby:regex"                  use-style="def:regexp" />
+  <style name="ruby:special-variable"       use-style="def:keyword" />
+  <style name="ruby:string"                 use-style="def:string" />
+  <style name="ruby:symbol"                 use-style="def:variable" />
+  <style name="ruby:variable"               use-style="def:variable" />
+
+  <!-- SH Styling -->
+  <style name="sh:comment"                  use-style="def:comment" />
+  <style name="sh:common-command"           foreground="matcha5" italic="true" />
+  <style name="sh:function"                 use-style="def:function" />
+  <style name="sh:here-doc-bound"           use-style="def:keyword" />
+  <style name="sh:keyword"                  use-style="def:keyword" />
+  <style name="sh:others"                   use-style="def:keyword" />
+  <style name="sh:string"                   use-style="def:string" />
+  <style name="sh:variable"                 use-style="def:variable" />
+  <style name="sh:variable-definition"      use-style="def:variable" />
+
+  <!-- XML Styling -->
+  <style name="xml:attribute-name"          use-style="def:attribute" />
+  <style name="xml:attribute-value"         use-style="def:string" />
+  <style name="xml:cdata-delim"             foreground="matcha1" bold="true" />
+  <style name="xml:comment"                 use-style="def:comment" />
+  <style name="xml:doctype"                 foreground="matcha6" />
+  <style name="xml:element-name"            use-style="def:keyword" />
+  <style name="xml:entity"                  use-style="def:escape" />
+  <style name="xml:error"                   use-style="def:error" />
+  <style name="xml:namespace"               use-style="def:namespace" />
+  <style name="xml:processing-instruction"  use-style="def:preprocessor" />
+  <style name="xml:tag"                     use-style="def:tag" />
+
+  <!-- Meld -->
+  <style name="meld:insert" foreground="matcha2" background="#rgba(77, 182, 172, 0.1)" line-background="#rgba(77, 182, 172, 0.1)" />
+  <style name="meld:replace" foreground="matcha2" background="#rgba(3, 169, 244, 0.1)" line-background="#rgba(3, 169, 244, 0.1)" />
+  <style name="meld:conflict" foreground="matcha2" background="#rgba(244, 67, 54, 0.1)" line-background="#rgba(244, 67, 54, 0.1)" />
+  <style name="meld:current-line-highlight" background="#rgba(203, 216, 220, 0.1)" />
+  <style name="meld:current-chunk-highlight" background="#rgba(203, 216, 220, 0.1)" />
+  <style name="meld:inline" background="#rgba(3, 169, 244, 0.4)" />
+  <style name="meld:unknown-text" foreground="matcha2" />
+  <style name="meld:dimmed" foreground="matcha1" />
+
+</style-scheme>


### PR DESCRIPTION
I created a new version of the matcha gedit theme.

What changed?
Matcha.xml file has specific values for background color, selected text, etc. More specifically, it has the colors of the dark sea theme. IMO, it's annoying when someone uses azul or aliz theme and gedit has the colors of the dark sea. Gedit is a gtk application and can switch backgrounds dynamically. So, I removed some theme values.
Also, i changed the colors. The reason is to look more like the colors of the Matcha theme.
Finally, i created the matchav2.xml which is more close to the Matcha's colors and changes the backgrounds dynamically (you can see the screenshots below).

/gedit/README.md file changed, cause the path was a bit broken.

![1](https://user-images.githubusercontent.com/40441225/81502448-54b89780-92de-11ea-9190-03f5744fc422.png)
![2](https://user-images.githubusercontent.com/40441225/81502449-57b38800-92de-11ea-8f36-b74288540cd6.png)
![3](https://user-images.githubusercontent.com/40441225/81502452-597d4b80-92de-11ea-9aba-ee3ec45beb1c.png)
![4](https://user-images.githubusercontent.com/40441225/81502453-5b470f00-92de-11ea-8512-986d34a01d05.png)
