### PR TITLE
Updating the README instructions for arch linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Usage:  `./install.sh`  **[OPTIONS...]**
 ### Install from repository
 
 Archlinux:
+This package is available in the AUR
 
-    sudo pacman -S matcha-gtk-theme
+    yay -S matcha-gtk-theme
 
 FreeBSD:
 


### PR DESCRIPTION
Added the appropriate instructions from installing the theme from the AUR as it doesn't appear to be present in the official repositories as per issue #132