### PR TITLE
Fix GTK scale highlight color contrast when in a hovered menuitem in some Xfce plugins

### DIFF
--- a/src/gtk-3.0/gtk-aliz.css
+++ b/src/gtk-3.0/gtk-aliz.css
@@ -9061,6 +9061,10 @@ window.thunar notebook header.top tab.reorderable-page > box > label {
   min-height: 0;
 }
 
+#pulseaudio-button menuitem:hover scale highlight, #xfce4-power-manager-plugin menuitem:hover scale highlight {
+  background-color: #ffffff;
+}
+
 /**********************
  * Elementary Desktop *
  **********************/

--- a/src/gtk-3.0/gtk-azul.css
+++ b/src/gtk-3.0/gtk-azul.css
@@ -9061,6 +9061,10 @@ window.thunar notebook header.top tab.reorderable-page > box > label {
   min-height: 0;
 }
 
+#pulseaudio-button menuitem:hover scale highlight, #xfce4-power-manager-plugin menuitem:hover scale highlight {
+  background-color: #ffffff;
+}
+
 /**********************
  * Elementary Desktop *
  **********************/

--- a/src/gtk-3.0/gtk-dark-aliz.css
+++ b/src/gtk-3.0/gtk-dark-aliz.css
@@ -9060,6 +9060,10 @@ window.thunar notebook header.top tab.reorderable-page > box > label {
   min-height: 0;
 }
 
+#pulseaudio-button menuitem:hover scale highlight, #xfce4-power-manager-plugin menuitem:hover scale highlight {
+  background-color: #ffffff;
+}
+
 /**********************
  * Elementary Desktop *
  **********************/

--- a/src/gtk-3.0/gtk-dark-azul.css
+++ b/src/gtk-3.0/gtk-dark-azul.css
@@ -9060,6 +9060,10 @@ window.thunar notebook header.top tab.reorderable-page > box > label {
   min-height: 0;
 }
 
+#pulseaudio-button menuitem:hover scale highlight, #xfce4-power-manager-plugin menuitem:hover scale highlight {
+  background-color: #ffffff;
+}
+
 /**********************
  * Elementary Desktop *
  **********************/

--- a/src/gtk-3.0/gtk-dark-sea.css
+++ b/src/gtk-3.0/gtk-dark-sea.css
@@ -9060,6 +9060,10 @@ window.thunar notebook header.top tab.reorderable-page > box > label {
   min-height: 0;
 }
 
+#pulseaudio-button menuitem:hover scale highlight, #xfce4-power-manager-plugin menuitem:hover scale highlight {
+  background-color: #ffffff;
+}
+
 /**********************
  * Elementary Desktop *
  **********************/

--- a/src/gtk-3.0/gtk-light-aliz.css
+++ b/src/gtk-3.0/gtk-light-aliz.css
@@ -9062,6 +9062,10 @@ window.thunar notebook header.top tab.reorderable-page > box > label {
   min-height: 0;
 }
 
+#pulseaudio-button menuitem:hover scale highlight, #xfce4-power-manager-plugin menuitem:hover scale highlight {
+  background-color: #ffffff;
+}
+
 /**********************
  * Elementary Desktop *
  **********************/

--- a/src/gtk-3.0/gtk-light-azul.css
+++ b/src/gtk-3.0/gtk-light-azul.css
@@ -9062,6 +9062,10 @@ window.thunar notebook header.top tab.reorderable-page > box > label {
   min-height: 0;
 }
 
+#pulseaudio-button menuitem:hover scale highlight, #xfce4-power-manager-plugin menuitem:hover scale highlight {
+  background-color: #ffffff;
+}
+
 /**********************
  * Elementary Desktop *
  **********************/

--- a/src/gtk-3.0/gtk-light-sea.css
+++ b/src/gtk-3.0/gtk-light-sea.css
@@ -9062,6 +9062,10 @@ window.thunar notebook header.top tab.reorderable-page > box > label {
   min-height: 0;
 }
 
+#pulseaudio-button menuitem:hover scale highlight, #xfce4-power-manager-plugin menuitem:hover scale highlight {
+  background-color: #ffffff;
+}
+
 /**********************
  * Elementary Desktop *
  **********************/

--- a/src/gtk-3.0/gtk-sea.css
+++ b/src/gtk-3.0/gtk-sea.css
@@ -9061,6 +9061,10 @@ window.thunar notebook header.top tab.reorderable-page > box > label {
   min-height: 0;
 }
 
+#pulseaudio-button menuitem:hover scale highlight, #xfce4-power-manager-plugin menuitem:hover scale highlight {
+  background-color: #ffffff;
+}
+
 /**********************
  * Elementary Desktop *
  **********************/

--- a/src/gtk-3.0/sass/apps/_xfce4.scss
+++ b/src/gtk-3.0/sass/apps/_xfce4.scss
@@ -303,3 +303,11 @@ window.thunar {
     header.top tab.reorderable-page > box > label { min-height: 0; }
   }
 }
+
+#pulseaudio-button, #xfce4-power-manager-plugin {
+  menuitem:hover {
+    scale highlight {
+      background-color: $selected_fg_color;
+    }
+  }
+}


### PR DESCRIPTION
Fix GTK scale highlight color contrast when in a hovered menuitem for the Xfce pulseaudio and power manager plugins (gtk 3)

Before:
![before](https://user-images.githubusercontent.com/53713479/106225886-50266d00-61e6-11eb-9420-79e3360df6f5.png)

After:
![after](https://user-images.githubusercontent.com/53713479/106225897-5583b780-61e6-11eb-83e5-3acf7c2e55c5.png)