### PR TITLE
Warn and exit when glib-compile-resource is not exist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -182,7 +182,12 @@ install_gdm() {
   echo
   echo "Installing ${2}${3}${4} gdm theme..."
 
-  if [[ -f "$GS_THEME_FILE" ]] && command -v glib-compile-resources >/dev/null ; then
+  if ! command -v glib-compile-resources >/dev/null ; then
+    echo "glib-compile-resources not found! Exit."
+    exit 1
+  fi
+
+  if [[ -f "$GS_THEME_FILE" ]] ; then
     echo "Installing '$GS_THEME_FILE'..."
     cp -an "$GS_THEME_FILE" "$GS_THEME_FILE.bak"
     glib-compile-resources \


### PR DESCRIPTION
This PR fix puzzles when users use a distribution without glib-compile-resource in default (e.g. Fedora Workstation 34).
It will warn glib-compile-resource is not exist and exit installation instead of just skip the compile step.