### PR TITLE
Fix Sea and Azil Progress Colors

### DIFF
--- a/src/gtk/sass/_colors.scss
+++ b/src/gtk/sass/_colors.scss
@@ -54,16 +54,16 @@ $warning_fg_color: white;
 $error_fg_color: white;
 $success_color: #2eb398;
 $destructive_color: #db5b5b;
-$suggested_color: #33b165;
+$suggested_color: #2eb398;
 $destructive_fg_color: white;
 $suggested_fg_color: white;
-$progress_color: #db5b5b;
+$progress_color: #2eb398;
 
 @if $color=='aliz' {
-    $progress_color: #2eb398;
+    $progress_color: #db5b5b;
     $success_color: #3498db;
     $destructive_color: #db5b5b;
-    $suggested_color: #2eb398;
+    $suggested_color: #db5b5b;
 }
 
 @if $color=='azul' {


### PR DESCRIPTION
This patch fixes the mis-matched volume/brightness OSD colors on the Matcha-Sea and Matcha-Azil themes as showcased here: https://github.com/vinceliuice/Matcha-gtk-theme/issues/182#issue-971216309

After merging, you will need to run parse-sass.sh to re-generate the themes with the appropriate colors.  

Resolves #182 

