### PR TITLE
Accent selected window background on alt-tab

### DIFF
--- a/src/gtk/sass/apps/_mate.scss
+++ b/src/gtk/sass/apps/_mate.scss
@@ -30,6 +30,10 @@ MsdOsdWindow.background.osd {
   }
 }
 
+.osd image:selected {
+  background: $selected_bg_color;
+}
+
 //
 // Mate/Gnome Flashback Panel
 //


### PR DESCRIPTION
**Before:**

![before](https://user-images.githubusercontent.com/49864414/149671600-e2262290-cdb9-4d31-8e73-1740393e1ffe.png)


**After:**

![ihategimp](https://user-images.githubusercontent.com/49864414/149671415-e3d9fe66-3bed-4917-9039-cad98e150bf1.png)

thanks to @sparkida (https://github.com/mate-desktop/marco/issues/614#issuecomment-1013786873)

fixes https://github.com/vinceliuice/Matcha-gtk-theme/issues/127